### PR TITLE
Allow unsetting and forcibly setting environment variables

### DIFF
--- a/doc/content/_index.md
+++ b/doc/content/_index.md
@@ -25,10 +25,10 @@
   wrappers.nushell = {
     basePackage = pkgs.nushell;
     flags = [
-      "--env-config ${./env.nu}"
-      "--config ${./config.nu}"
+      "--env-config" ./env.nu
+      "--config" ./config.nu
     ];
-    env.STARSHIP_CONFIG = ../starship.toml;
+    env.STARSHIP_CONFIG.value = ../starship.toml;
     pathAdd = [
       pkgs.starship
       pkgs.carapace
@@ -149,6 +149,12 @@ These are some examples of wrapper-manager used in the wild. Feel free to PR you
 https://github.com/viperML/wrapper-manager/issues
 
 ## Changelog
+
+- TBA
+  - Changed wrapper.name.env to be an attrset instead
+  - Added the ability to unset a variable with wrapper.name.env.unset
+  - Added the ability to disallow overriding a variable with wrapper.name.env.force
+  - Changed the way wrapper.name.flags is handled so that every flag is escaped
 
 - 2023-08-12
   - Added wrappers.name.renames option.

--- a/modules/env-type.nix
+++ b/modules/env-type.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  name,
+  ...
+}: let
+  inherit (lib) mkOption types mdDoc;
+in {
+  options = {
+    name = mkOption {
+      type = types.str;
+      description = mdDoc ''
+        Name of the variable.
+      '';
+      default = name;
+    };
+
+    value = mkOption {
+      type = let
+        inherit (types) coercedTo anything str nullOr;
+        strLike = coercedTo anything (x: "${x}") str;
+      in
+        nullOr strLike;
+      description = mdDoc ''
+        Value of the variable to be set.
+        Set to `null` to unset the variable.
+      '';
+    };
+
+    force = mkOption {
+      type = types.bool;
+      description = mdDoc ''
+        Whether the value should be always set to the specified value.
+        If set to `true`, the program will not inherit the value of the variable
+        if it's already present in the environment.
+
+        Setting it to false when unsetting a variable (value = null)
+        will make the option have no effect.
+      '';
+      default = config.value == null;
+      defaultText = lib.literalMD "true if `value` is null, otherwise false";
+    };
+  };
+}

--- a/tests/test-module.nix
+++ b/tests/test-module.nix
@@ -25,7 +25,7 @@
   wrappers.git = {
     basePackage = pkgs.git;
     extraPackages = [pkgs.git-extras];
-    env.GIT_CONFIG_GLOBAL = pkgs.writeText "gitconfig" (lib.fileContents ./gitconfig);
+    env.GIT_CONFIG_GLOBAL.value = pkgs.writeText "gitconfig" (lib.fileContents ./gitconfig);
   };
 
   wrappers.nushell = {


### PR DESCRIPTION
Closes #4.

On top of adding the ability to unset or forcibly set a value of a variable, I cleaned up the code a little and added shell argument escaping, so that every flag in `flags` actually gets treated as a separate argument and the end-user doesn't have to worry about using `escapeShellArg` or ensuring there's no illegal characters.