### PR TITLE
Merge all module arguments into one attribute, `moduleArgs`

### DIFF
--- a/doc/content/_index.md
+++ b/doc/content/_index.md
@@ -104,7 +104,10 @@ The `lib` output is a function that evaluates the module with an optional set of
 
 ```nix
 wrapper-manager.lib {
-  moduleArgs = { inherit pkgs config; };
+  moduleArgs = {
+    inherit pkgs;
+    nixosCfg = config;
+  };
   modules = [
     ./my-module.nix
   ];

--- a/doc/content/_index.md
+++ b/doc/content/_index.md
@@ -100,11 +100,11 @@ First, bring wrapper-manager as a flake input:
 }
 ```
 
-The `lib` output is a function that evaluates the module:
+The `lib` output is a function that evaluates the module with an optional set of module arguments:
 
 ```nix
 wrapper-manager.lib {
-  inherit pkgs;
+  moduleArgs = { inherit pkgs config; };
   modules = [
     ./my-module.nix
   ];
@@ -126,7 +126,7 @@ Wrapper-manager can be evaluated in any context that accepts a package, like in
   users.users.my-user.packages = [
 
     (wrapper-manager.lib.build {
-      inherit pkgs;
+      moduleArgs = { inherit pkgs; };
       modules = [
         ./my-module.nix
       ];
@@ -149,6 +149,10 @@ These are some examples of wrapper-manager used in the wild. Feel free to PR you
 https://github.com/viperML/wrapper-manager/issues
 
 ## Changelog
+
+- 2023-11-06
+  - Add `moduleArgs` attribute to lib
+  - Remove explicit `pkgs` argument (users may pass `pkgs` into `moduleArgs`)
 
 - 2023-11-06
   - Users can now pass their own `specialArgs`

--- a/flake.nix
+++ b/flake.nix
@@ -34,11 +34,11 @@
 
     checks = forAllSystems (pkgs:
       (self.lib {
-        inherit pkgs;
-        modules = [./tests/test-module.nix];
-        specialArgs = {
+        moduleArgs = {
+          inherit pkgs;
           some-special-arg = "foo";
         };
+        modules = [./tests/test-module.nix];
       })
       .config
       .build

--- a/lib.nix
+++ b/lib.nix
@@ -1,8 +1,7 @@
 {lib}: let
   eval = {
-    pkgs,
     modules ? [],
-    specialArgs ? {},
+    moduleArgs ? {},
   }:
     lib.evalModules {
       modules =
@@ -10,7 +9,7 @@
           ./modules
         ]
         ++ modules;
-      specialArgs = {inherit pkgs;} // specialArgs;
+      specialArgs = moduleArgs;
     };
 in {
   __functor = _: eval;


### PR DESCRIPTION
Requiring `pkgs` isn't ideal, since some consumers might not actually need or even have nixpkgs in scope. This PR removes the special `pkgs` attribute from lib, and adds the attribute `moduleArgs`.

Additionally, `specialArgs` has been removed from lib, since those can just be merged into `moduleArgs`.

This will break existing configs that pass either of `pkgs` or `specialArgs`. I'm sure that an intermediate implementation could be written that warns users, but I wanted to get this PR open while I still had steam on it :grinning:.