### PR TITLE
Fix nix repl execution

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{lib}: let
+{lib ? (import <nixpkgs> {}).lib}: let
   eval = {
     pkgs,
     modules ? [],


### PR DESCRIPTION
Without the default value, using `:l <wrapper-manager>` in nix repl results in an error, because lib is not specified. A similar expression can be found in home-manager and in sops-nix.