### PR TITLE
fix: readme.md now uses the right url for flakes

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -134,7 +134,7 @@ The main entrypoint is `wrapper-manager.lib`. To get it:
 
 ```nix
 {
-  inputs.wrapper-manager.url = "github.com:viperML/wrapper-manager";
+  inputs.wrapper-manager.url = "github:viperML/wrapper-manager";
 
   outputs = {self, wrapper-manager}: let
     # wrapper-manager.lib { ... }


### PR DESCRIPTION
The section on how to get wrapper-manager has wrong url in the flakes snippet: `github.com:viperML/wrapper-manager` -> `github:viperML/wrapper-manager`